### PR TITLE
Updated platform to .NET 6 and TFTLT patch 2.03

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -12,7 +12,14 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
 [assembly: Guid("36e8bdaf-a46d-4729-b60d-f42190a089dc")]
-[assembly: AssemblyVersion("1.3.1.0")]
-[assembly: AssemblyFileVersion("1.3.1.0")]
-[assembly: MelonModInfo(typeof(RememberBreakDownItem.RememberBreakDownItemMod), "RememberBreakDownItem", "1.3.1", "zeobviouslyfakeacc")]
-[assembly: MelonModGame("Hinterland", "TheLongDark")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]
+[assembly: MelonInfo(typeof(RememberBreakDownItem.RememberBreakDownItemMod), BuildInfo.ModName, BuildInfo.ModVersion, BuildInfo.ModAuthor)]
+[assembly: MelonGame("Hinterland", "TheLongDark")]
+
+internal static class BuildInfo
+{
+    internal const string ModName = "RememberBreakDownItem";
+    internal const string ModAuthor = "zeobviouslyfakeacc";
+    internal const string ModVersion = "2.0.0";
+}

--- a/RememberBreakDownItem.cs
+++ b/RememberBreakDownItem.cs
@@ -1,16 +1,19 @@
 ﻿using System;
 using System.Collections.Generic;
-using Harmony;
+using UnityEngine;
+using HarmonyLib;
 using MelonLoader;
-using Il2Cpp = Il2CppSystem.Collections.Generic;
+using Il2Cpp;
 
 internal static class RememberBreakDownItem {
 
 	internal class RememberBreakDownItemMod : MelonMod {
-		public override void OnApplicationStart() {
-			UnityEngine.Debug.Log($"[{InfoAttribute.Name}] version {InfoAttribute.Version} loaded!");
-		}
-	}
+        public override void OnInitializeMelon()
+        {
+            Debug.Log($"[{Info.Name}] version {Info.Version} loaded");
+            new MelonLogger.Instance($"{Info.Name}").Msg($"Version {Info.Version} loaded");
+        }
+    }
 
 	private static readonly Dictionary<string, int> rememberedToolIDs = new Dictionary<string, int>();
 	private static int lastUsedID = -1;
@@ -83,7 +86,7 @@ internal static class RememberBreakDownItem {
 			return;
 		}
 
-		Il2Cpp.List<GearItem> tools = panel.m_Tools;
+		var tools = panel.m_Tools;
 
 		int index = -1;
 		for (int i = 0; i < tools.Count; ++i) {

--- a/RememberBreakDownItem.csproj
+++ b/RememberBreakDownItem.csproj
@@ -1,64 +1,34 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{36E8BDAF-A46D-4729-B60D-F42190A089DC}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>RememberBreakDownItem</RootNamespace>
-    <AssemblyName>RememberBreakDownItem</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Assembly-CSharp">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Il2Cppmscorlib">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Il2CppSystem">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="MelonLoader.ModHandler">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="UnhollowerBaseLib">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnhollowerRuntimeLib">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.CoreModule">
-      <Private>False</Private>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="RememberBreakDownItem.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<!--This is an xml comment. Comments have no impact on compiling.-->
+
+	<PropertyGroup>
+		<!--This is the .NET version the mod will be compiled with. Don't change it.-->
+		<TargetFramework>net6.0</TargetFramework>
+
+		<!--This tells the compiler to use the latest C# version.-->
+		<LangVersion>Latest</LangVersion>
+
+		<!--This adds global usings for a few common System namespaces.-->
+		<ImplicitUsings>enable</ImplicitUsings>
+
+		<!--This enables nullable annotation and analysis. It's good coding form.-->
+		<Nullable>enable</Nullable>
+
+		<!--This tells the compiler to use assembly attributes instead of generating its own.-->
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+
+		<!--PDB files give line numbers in stack traces (errors). This is useful for debugging. There are 3 options:-->
+		<!--full has a pdb file created beside the dll.-->
+		<!--embedded has the pdb data embedded within the dll. This is useful because bug reports will then have line numbers.-->
+		<!--none skips creation of pdb data.-->
+		<DebugType>embedded</DebugType>
+	</PropertyGroup>
+
+	<!--This is the of packages that the mod references.-->
+	<ItemGroup>
+		<!--This package contains almost everything a person could possibly need to reference while modding.-->
+		<PackageReference Include="STBlade.Modding.TLD.Il2CppAssemblies.Windows" Version="2.10.0" />
+		<!--The package version here in this template may be outdated and need to be updated. Visual Studio can update package versions automatically.-->
+		<!--If the mod references any other mods (such as ModSettings), that NuGet package will also need to be listed here.-->
+	</ItemGroup>
 </Project>


### PR DESCRIPTION
Simple update to make Remember Breakdown Item compatible with the post-TFTFT release. Tested on latest game version 2.14.

Updated assemblies and dependencies for newest version of MelonLoader and .NET 6
